### PR TITLE
Add extra entry point to Moonlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ public enum Scene {
         window.makeKeyAndVisible()
         
         /*
-        Moonlight also has an alternative usage that can be more convenient if you want to return some value from a child scene:
+        Moonlight also has an alternative usage that can be more convenient
+        if you want to return some value from a child scene:
         
         return Moonlight.start(
             initialState: SceneState(),

--- a/README.md
+++ b/README.md
@@ -59,6 +59,22 @@ public enum Scene {
         
         window.rootViewController = vc
         window.makeKeyAndVisible()
+        
+        /*
+        Moonlight also has an alternative usage that can be more convenient if you want to return some value from a child scene:
+        
+        return Moonlight.start(
+            initialState: SceneState(),
+            environment: env,
+            feedback: vc.bind,
+            transform: SceneReducer.transform,
+            apply: SceneReducer.apply,
+            store: vc.store
+        )
+        .compactMap(\.result)
+        .handleEvents(receiveOutput: { [vc] _ in vc.dismiss(animated: true) })
+        .eraseToAnyPublisher()
+        */
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ public enum ParentScene {
         ).store(in: &vc.subscriptions)
         
         window.rootViewController = vc
-        window.makeKeyAndVisible()        
+        window.makeKeyAndVisible()
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ import Combine
 import Moonlight
 import UIKit
 
-public enum Scene {
+// If the Scene isn't supposed to return a value
+public enum ParentScene {
     
     public static func create(
         in window: UIWindow,
@@ -58,11 +59,25 @@ public enum Scene {
         ).store(in: &vc.subscriptions)
         
         window.rootViewController = vc
-        window.makeKeyAndVisible()
+        window.makeKeyAndVisible()        
+    }
+}
+
+// If the Scene is supposed to return some value.
+public enum ChildScene {
+    
+    public static func create(
+        in window: UIWindow,
+        dependency1: @escaping () -> AnyPublisher<Int, Never>,
+        dependency2: @escaping () -> AnyPublisher<String, Never>
+    ) {
+
+        let env = SceneEnvironment(
+            dependency1: dependency1,
+            dependency2: dependency2
+        )
         
-        /*
-        Moonlight also has an alternative usage that can be more convenient
-        if you want to return some value from a child scene:
+        let vc = ViewController()
         
         return Moonlight.start(
             initialState: SceneState(),
@@ -75,9 +90,9 @@ public enum Scene {
         .compactMap(\.result)
         .handleEvents(receiveOutput: { [vc] _ in vc.dismiss(animated: true) })
         .eraseToAnyPublisher()
-        */
     }
 }
+
 
 // MARK: Reducer
 

--- a/Sources/Moonlight/Moonlight.swift
+++ b/Sources/Moonlight/Moonlight.swift
@@ -24,9 +24,41 @@ public enum Moonlight {
             .flatMap { event in transform(stateSubject.value, event, environment) }
             .sink(receiveValue: effectSubject.send)
 
-        return AnyCancellable.init {
+        return AnyCancellable {
             eventsSubscription.cancel()
             effectsSubscription.cancel()
         }
+    }
+    
+    public static func start<State, Event, Effect, Environment>(
+        initialState: State,
+        environment: Environment,
+        feedback: (AnyPublisher<State, Never>) -> AnyPublisher<Event, Never>,
+        transform: @escaping (State, Event, Environment) -> AnyPublisher<Effect, Never>,
+        apply: @escaping (State, Effect) -> State,
+        store: (AnyCancellable) -> Void
+    ) -> AnyPublisher<State, Never> {
+        let effectSubject = PassthroughSubject<Effect, Never>()
+
+        let stateSubject = CurrentValueSubject<State, Never>(initialState)
+
+        let state = stateSubject.share().eraseToAnyPublisher()
+
+        let effectsSubscription = effectSubject
+            .scan(initialState, apply)
+            .sink(receiveValue: stateSubject.send)
+
+        let eventsSubscription = feedback(state)
+            .flatMap { event in transform(stateSubject.value, event, environment) }
+            .sink(receiveValue: effectSubject.send)
+
+        let subscription = AnyCancellable {
+            eventsSubscription.cancel()
+            effectsSubscription.cancel()
+        }
+
+        store(subscription)
+
+        return state.eraseToAnyPublisher()
     }
 }


### PR DESCRIPTION
## Context

<!-- Please provide a short description or a link to documentation. -->
In some cases it's very convenience to have a possibility to return result value from child scene to a parent one. For this purpose I extended Moonlight with one more function's signature, which allows to use the approach like this:
```swift
return Moonlight.start(
            initialState: SceneState(),
            environment: env,
            feedback: vc.bind,
            transform: SceneReducer.transform,
            apply: SceneReducer.apply,
            store: vc.store
        )
        .compactMap(\.result)
        .handleEvents(receiveOutput: { [vc] _ in vc.dismiss(animated: true) })
        .eraseToAnyPublisher()
```

## Checklist

<!-- Please check all the points that apply to this pull request. -->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation including README.md
- [x] My changes generate no new warnings
- [x] My changes generate no breaking changes