### PR TITLE
Move Test framework to a separate Library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,20 +5,10 @@ let package = Package(
     name: "MoonKit",
     platforms: [.iOS(.v13)],
     products: [
-        .library(
-            name: "MoonKitTests",
-            targets: [
-                "MoonlightTests"
-            ]
-        ),
-        .library(
-            name: "MoonKit",
-            targets: [
-                "Moonlight",
-                "MoonFoundation",
-                "MoonPresentation"
-            ]
-        )
+        .library(name: "Moonlight", targets: ["Moonlight"]),
+        .library(name: "MoonlightTests", targets: ["MoonlightTests"]),
+        .library(name: "MoonFoundation", targets: ["MoonFoundation"]),
+        .library(name: "MoonPresentation", targets: ["MoonPresentation"])
     ],
     targets: [
         .target(name: "Moonlight"),

--- a/Package.swift
+++ b/Package.swift
@@ -6,10 +6,15 @@ let package = Package(
     platforms: [.iOS(.v13)],
     products: [
         .library(
+            name: "MoonKitTests",
+            targets: [
+                "MoonlightTests"
+            ]
+        ),
+        .library(
             name: "MoonKit",
             targets: [
                 "Moonlight",
-                "MoonlightTests",
                 "MoonFoundation",
                 "MoonPresentation"
             ]


### PR DESCRIPTION
## Context

For splitting test targets and regular targets, 'MoonlightTests' should be moved to a separate library.

## Checklist

<!-- Please check all the points that apply to this pull request. -->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation including README.md
- [x] My changes generate no new warnings
- [x] My changes generate no breaking changes